### PR TITLE
No manifest found

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm install
 Then you need to actually create the extension:
 
 ```cmd
-tfx extension create
+tfx extension create --manifest-globs vss-extension.json
 ```
 
 This will generate the _.vsix_ package file


### PR DESCRIPTION
Hi CodeDave, I tried to run your tutorial, but when installing the extension I had an issue. ADO failed installation with error: missing manifest file.
I went to the main documentation page and I found that the command is different from yours:
https://docs.microsoft.com/en-us/azure/devops/extend/develop/add-build-task?view=azure-devops#step-4-package-your-extension
I re-generated the extension and it worked. 
I suggest you to do this change.
Ciao, Francesco